### PR TITLE
Replace deprecated use_container_width with width="stretch"

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,8 +115,8 @@ fig_hourly_sales.update_layout(
 
 
 left_column, right_column = st.columns(2)
-left_column.plotly_chart(fig_hourly_sales, use_container_width=True)
-right_column.plotly_chart(fig_product_sales, use_container_width=True)
+left_column.plotly_chart(fig_hourly_sales, width="stretch")
+right_column.plotly_chart(fig_product_sales, width="stretch")
 
 
 # ---- HIDE STREAMLIT STYLE ----


### PR DESCRIPTION
Replaced deprecated `use_container_width` parameter with `width="stretch"` in `plotly_chart` calls.

This removes deprecation warnings and updates the app to the current Streamlit API.

Verified that the dashboard still renders correctly after the change.